### PR TITLE
Fixed wrong variable being used in onTick

### DIFF
--- a/Components/Bullet/src/OgreBullet.cpp
+++ b/Components/Bullet/src/OgreBullet.cpp
@@ -107,7 +107,7 @@ static void onTick(btDynamicsWorld* world, btScalar timeStep)
 
         for (int j = 0; j < manifold->getNumContacts(); j++)
         {
-            const btManifoldPoint& mp = manifold->getContactPoint(i);
+            const btManifoldPoint& mp = manifold->getContactPoint(j);
             auto body0 = static_cast<EntityCollisionListener*>(manifold->getBody0()->getUserPointer());
             auto body1 = static_cast<EntityCollisionListener*>(manifold->getBody1()->getUserPointer());
             if (body0->listener)


### PR DESCRIPTION
getContactPoint() was using the i variable instead of the j variable which was meant to be used to refer to the contact point index.